### PR TITLE
check for failure after every read operation

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -201,12 +201,22 @@ int crypto_decrypt_file(std::ifstream &fp, size_t file_size, unsigned char *plai
 
     fp.read((char *) header, sizeof(header));
 
+    if (!fp) {
+        free(buf_cipher);
+        return -3;
+    }
+
     if (crypto_secretstream_xchacha20poly1305_init_pull(&state, header, key) != 0) {
         free(buf_cipher);
         return -2;
     }
 
     fp.read((char *) buf_cipher, cipher_len);
+
+    if (!fp) {
+        free(buf_cipher);
+        return -3;
+    }
 
     if (crypto_secretstream_xchacha20poly1305_pull(&state, plaintext, plain_len, &tag,
             buf_cipher, fp.gcount(), NULL, 0) != 0) {

--- a/src/load.cpp
+++ b/src/load.cpp
@@ -160,8 +160,22 @@ static int read_header(ifstream &fp, unsigned char *format_version, unsigned cha
     }
 
     fp.read((char *) format_version, sizeof(unsigned char));
+
+    if (!fp) {
+        return -1;
+    }
+
     fp.read((char *) hash, CRYPTO_HASH_SIZE);
+
+    if (!fp) {
+        return -1;
+    }
+
     fp.read((char *) salt, CRYPTO_SALT_SIZE);
+
+    if (!fp) {
+        return -1;
+    }
 
     if (fp.tellg() != PASS_STORE_HEADER_SIZE) {
         return -1;


### PR DESCRIPTION
This isn't strictly necessary in these cases but it's good practice