### PR TITLE
Don't print password when adding a new entry via CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ x32/*
 *~
 _build/*
 .gitattributes
+.nvimlog

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -314,7 +314,7 @@ static int add(Pass_Store &p)
 
     switch (ret) {
         case 0: {
-            cout << "Added key " << key << " with password " << password << endl;
+            cout << "Added new entry with key \"" << key << "\"" << endl;
             return 0;
         }
 


### PR DESCRIPTION
This is to prevent accidental logging/exposure of passwords