### PR TITLE
Add command-line option to export entries to plaintext file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,8 @@ jobs:
             libgtest-dev
             libsodium-dev
             pkg-config
+            openssh-client
+            git
 
       - run: |
             CC=clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(GLADE_FILE_PATH ${SPICYPASS_INSTALL_DIRECTORY}/gui.glade)
 set(SpicyPass_LOGO_FILE_PATH ${SPICYPASS_INSTALL_DIRECTORY}/spicypass.svg)
 
 set(SpicyPass_VERSION_MAJOR "0")
-set(SpicyPass_VERSION_MINOR "6")
+set(SpicyPass_VERSION_MINOR "7")
 set(SpicyPass_VERSION_PATCH "2")
 
 set(CMAKE_CXX_STANDARD 17)

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -26,6 +26,8 @@
 #include "crypto.hpp"
 #include "cli.hpp"
 
+#define EXPORT_PATH "spicypass_export"
+
 typedef enum {
     OPT_EXIT = 0,
     OPT_ADD,
@@ -34,6 +36,7 @@ typedef enum {
     OPT_LIST,
     OPT_GENERATE,
     OPT_PASSWORD,
+    OPT_EXPORT,
     OPT_PRINT,
 } Options;
 
@@ -557,8 +560,36 @@ static void print_menu(void)
     cout << "[" << to_string(OPT_LIST)       << "] List all entries" << endl;
     cout << "[" << to_string(OPT_GENERATE)   << "] Generate password" << endl;
     cout << "[" << to_string(OPT_PASSWORD)   << "] Change master password" << endl;
+    cout << "[" << to_string(OPT_EXPORT)     << "] Export entries to plaintext file" << endl;
     cout << "[" << to_string(OPT_PRINT)      << "] Print menu" << endl;
     cout << "[" << to_string(OPT_EXIT)       << "] Exit" << endl;
+}
+
+static int export_entries(Pass_Store &p)
+
+{
+    vector<tuple<string, const char *>> result;
+    int matches = p.get_matches("", result, false);
+
+    if (matches == PASS_STORE_LOCKED) {
+        return PASS_STORE_LOCKED;
+    }
+
+    string export_path = get_export_path();
+
+    if (export_path.size() == 0) {
+        cerr << "Failed to export pass store." << endl;
+        return -1;
+    }
+
+    cout << "Exported pass store entries to plaintext file: " << export_path << endl;
+
+    if (export_pass_store_to_plaintext(p) != 0) {
+        cerr << "Failed to export pass store." << endl;
+        return -1;
+    }
+
+    return 0;
 }
 
 /*
@@ -608,6 +639,11 @@ static int execute(const int option, Pass_Store &p)
 
         case OPT_PASSWORD: {
             ret = new_password(p);
+            break;
+        }
+
+        case OPT_EXPORT: {
+            export_entries(p);
             break;
         }
 

--- a/src/load.hpp
+++ b/src/load.hpp
@@ -96,4 +96,17 @@ int init_pass_hash(const unsigned char *password, size_t length);
  */
 int update_crypto(Pass_Store &p, const unsigned char *password, size_t length);
 
+/*
+ * Writes contents of pass store to a plaintext file.
+ *
+ * Return 0 on success.
+ * Return -1 on failure.
+ */
+int export_pass_store_to_plaintext(Pass_Store &p);
+
+/*
+ * Returns a string containing export file path.
+ */
+string get_export_path(void);
+
 #endif // LOAD_H

--- a/src/spicy.hpp
+++ b/src/spicy.hpp
@@ -665,6 +665,26 @@ public:
     }
 
     /*
+     * Writes pass store contents to a plaintext file.
+     *
+     * Return 0 on success.
+     * Return PASS_STORE_LOCKED if pass store is locked.
+     */
+    int _export(ofstream &fp)
+    {
+        if (check_lock()) {
+            return PASS_STORE_LOCKED;
+        }
+
+        for (const auto &[key, value] : store) {
+            string entry = format_entry(key, value->password);
+            fp << entry << DELIMITER << endl;
+        }
+
+        return 0;
+    }
+
+    /*
      * Securely wipes all sensitive pass store data from memory.
      */
     void clear(void)


### PR DESCRIPTION
This allows us to make manual backups of the pass store contents rather than being forced to rely on spicypass.