### PR TITLE
Simplify crypto_gen_salt()

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -112,16 +112,9 @@ bool crypto_verify_pass_hash(const unsigned char *hash, const unsigned char *pas
     return crypto_pwhash_str_verify((const char *) hash, (const char *) password, length) == 0;
 }
 
-/*
- * Generates a random salt of `length` bytes and puts it in `salt`.
- *
- * `length` must be at least 16 bytes.
- */
-void crypto_gen_salt(unsigned char *salt, size_t length)
+void crypto_gen_salt(unsigned char *salt)
 {
-    assert(length >= 16);
-
-    randombytes_buf(salt, length);
+    randombytes_buf(salt, CRYPTO_SALT_SIZE);
 }
 
 /*

--- a/src/crypto.hpp
+++ b/src/crypto.hpp
@@ -116,11 +116,10 @@ int crypto_derive_key_from_pass(const unsigned char *key, size_t keylen, const u
                                 size_t pwlen, const unsigned char *salt, Hash_Parameters *params);
 
 /*
- * Generates a random salt of `length` bytes and puts it in `salt`.
- *
- * `length` must be at least 16 bytes.
+ * Generates a random salt of CRYPTO_SALT_SIZE bytes in length. `salt` must have room
+ * for at least that many bytes.
  */
-void crypto_gen_salt(unsigned char *salt, size_t length);
+void crypto_gen_salt(unsigned char *salt);
 
 /*
  * Decrypts file pointed to by `fp` using `key`. Puts result in `plaintext` and the

--- a/src/load.cpp
+++ b/src/load.cpp
@@ -428,7 +428,7 @@ int init_pass_hash(const unsigned char *password, size_t length)
     }
 
     unsigned char salt[CRYPTO_SALT_SIZE];
-    crypto_gen_salt(salt, CRYPTO_SALT_SIZE);
+    crypto_gen_salt(salt);
 
     ofstream fp;
     int ret = get_pass_store_of(fp, false);
@@ -475,7 +475,7 @@ int update_crypto(Pass_Store &p, const unsigned char *password, size_t length)
         return -1;
     }
 
-    crypto_gen_salt(salt, CRYPTO_SALT_SIZE);
+    crypto_gen_salt(salt);
 
     if (crypto_derive_key_from_pass(encryption_key, CRYPTO_KEY_SIZE, password, length, salt, &params) != 0) {
         cerr << "crypto_derive_key_from_pass() failed" << endl;


### PR DESCRIPTION
We never need to generate salts of different lengths