### PR TITLE
Add file lock and some code cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ set(DESKTOP_FILE_PATH ${APPLICATIONS_DIRECTORY}/spicypass.desktop)
 set(SpicyPass_LOGO_FILE_PATH ${SPICYPASS_INSTALL_DIRECTORY}/spicypass.svg)
 
 set(SpicyPass_VERSION_MAJOR "0")
-set(SpicyPass_VERSION_MINOR "7")
-set(SpicyPass_VERSION_PATCH "7")
+set(SpicyPass_VERSION_MINOR "8")
+set(SpicyPass_VERSION_PATCH "0")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -160,7 +160,7 @@ static int init_new_password(Pass_Store &p, unsigned char *password, size_t max_
  * Prompts user to update password for pass store file.
  *
  * Return 0 on success.
-const string filename,  * Return -1 on failure.
+ * Return -1 on failure.
  * Return PASS_STORE_LOCKED if pass store is locked.
  */
 static int change_password_prompt(Pass_Store &p)

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -56,7 +56,7 @@ static int prompt_password(unsigned char *password, size_t max_length)
         return -1;
     }
 
-    size_t pass_length = strlen(pass_buf);
+    const size_t pass_length = strlen(pass_buf);
 
     if (pass_length > max_length) {
         return -1;
@@ -91,7 +91,7 @@ static int new_password_prompt(Pass_Store &p, unsigned char *password, size_t ma
             continue;
         }
 
-        size_t pass_length = strlen(pass1);
+        const size_t pass_length = strlen(pass1);
 
         if (pass_length < MIN_MASTER_PASSWORD_SIZE || pass_length > max_length) {
             cout << "Password must be between " << MIN_MASTER_PASSWORD_SIZE  << " and " << (max_length - 1) << " characters long" <<
@@ -139,7 +139,7 @@ static int new_password_prompt(Pass_Store &p, unsigned char *password, size_t ma
 static int init_new_password(Pass_Store &p, unsigned char *password, size_t max_length)
 {
     terminal_echo(false);
-    int ret = new_password_prompt(p, password, max_length);
+    const int ret = new_password_prompt(p, password, max_length);
     terminal_echo(true);
 
     if (ret == PASS_STORE_LOCKED) {
@@ -160,7 +160,7 @@ static int init_new_password(Pass_Store &p, unsigned char *password, size_t max_
  * Prompts user to update password for pass store file.
  *
  * Return 0 on success.
- * Return -1 on failure.
+const string filename,  * Return -1 on failure.
  * Return PASS_STORE_LOCKED if pass store is locked.
  */
 static int change_password_prompt(Pass_Store &p)
@@ -191,7 +191,7 @@ static int change_password_prompt(Pass_Store &p)
 
         cout << "Validating password..." << endl;
 
-        size_t pass_length = strlen(old_pass);
+        const size_t pass_length = strlen(old_pass);
 
         if (!p.validate_password((unsigned char *) old_pass, pass_length)) {
             cout << "Invalid password" << endl;
@@ -207,7 +207,7 @@ static int change_password_prompt(Pass_Store &p)
 
     cout << "Generating new encryption key..." << endl;
 
-    int ret = update_crypto(p, new_password, strlen((char *) new_password));
+    const int ret = update_crypto(p, new_password, strlen((char *) new_password));
 
     crypto_memwipe(new_password, sizeof(new_password));
 
@@ -228,7 +228,7 @@ static int change_password_prompt(Pass_Store &p)
 static int new_password(Pass_Store &p)
 {
     terminal_echo(false);
-    int ret = change_password_prompt(p);
+    const int ret = change_password_prompt(p);
     terminal_echo(true);
 
     return ret;
@@ -284,7 +284,7 @@ static int add(Pass_Store &p)
         return -1;
     }
 
-    int exists = p.key_exists(key);
+    const int exists = p.key_exists(key);
 
     if (exists == PASS_STORE_LOCKED) {
         return PASS_STORE_LOCKED;
@@ -309,7 +309,7 @@ static int add(Pass_Store &p)
         return -1;
     }
 
-    int ret = save_password_store(p);
+    const int ret = save_password_store(p);
 
     switch (ret) {
         case 0: {
@@ -367,7 +367,7 @@ static int remove(Pass_Store &p)
         cout << "Invalid option" << endl;
     }
 
-    int removed = p.remove(key);
+    const int removed = p.remove(key);
 
     if (removed == PASS_STORE_LOCKED) {
         return PASS_STORE_LOCKED;
@@ -380,7 +380,7 @@ static int remove(Pass_Store &p)
 
     cout << "Removed \"" << key << "\" from pass store" << endl;
 
-    int ret = save_password_store(p);
+    const int ret = save_password_store(p);
 
     if (ret != 0) {
         cerr << "Failed to save password store (error code: " << to_string(ret) << ")" << endl;
@@ -406,7 +406,7 @@ static int fetch(Pass_Store &p)
     }
 
     vector<tuple<string, const char *>> result;
-    int matches = p.get_matches(key, result, false);
+    const int matches = p.get_matches(key, result, false);
 
     if (matches == PASS_STORE_LOCKED) {
         return PASS_STORE_LOCKED;
@@ -431,7 +431,7 @@ static int fetch(Pass_Store &p)
 static int list(Pass_Store &p)
 {
     vector<tuple<string, const char *>> result;
-    int matches = p.get_matches("", result, false);
+    const int matches = p.get_matches("", result, false);
 
     if (matches == PASS_STORE_LOCKED) {
         return PASS_STORE_LOCKED;
@@ -499,7 +499,7 @@ static bool unlock_prompt(Pass_Store &p)
 
     cout << "Decrypting pass store file..." << endl;
 
-    int ret = load_password_store(p, pass, strlen((char *) pass));
+    const int ret = load_password_store(p, pass, strlen((char *) pass));
 
     crypto_memwipe(pass, sizeof(pass));
 
@@ -568,7 +568,7 @@ static int export_entries(Pass_Store &p)
         return PASS_STORE_LOCKED;
     }
 
-    string export_path = get_export_path();
+    string export_path = get_store_path(EXPORT_FILENAME, false);
 
     if (export_path.size() == 0) {
         cerr << "Failed to export pass store." << endl;
@@ -582,7 +582,7 @@ static int export_entries(Pass_Store &p)
     unsigned char password[MAX_STORE_PASSWORD_SIZE + 2];
 
     terminal_echo(false);
-    int pw_ret = prompt_password(password, sizeof(password) - 1);
+    const int pw_ret = prompt_password(password, sizeof(password) - 1);
     terminal_echo(true);
 
     cout << endl;
@@ -701,7 +701,7 @@ int cli_new_pass_store(Pass_Store &p)
         }
     } else {
         terminal_echo(false);
-        int pw_ret = prompt_password(password, sizeof(password) - 1);
+        const int pw_ret = prompt_password(password, sizeof(password) - 1);
         terminal_echo(true);
 
         cout << endl;
@@ -713,7 +713,7 @@ int cli_new_pass_store(Pass_Store &p)
 
     cout << "Decrypting pass store file..." << endl;
 
-    int ret = load_password_store(p, password, strlen((char *) password));
+    const int ret = load_password_store(p, password, strlen((char *) password));
 
     crypto_memwipe(password, sizeof(password));
 
@@ -750,8 +750,8 @@ static void menu_loop(Pass_Store &p)
     print_menu();
 
     while (true) {
-        int option = command_prompt();
-        int ret = execute(option, p);
+        const int option = command_prompt();
+        const int ret = execute(option, p);
 
         switch (ret) {
             case 0: {

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -120,7 +120,7 @@ int crypto_decrypt_file(std::ifstream &fp, size_t file_size, unsigned char *plai
         return -3;
     }
 
-    size_t cipher_len = file_size - sizeof(header);
+    const size_t cipher_len = file_size - sizeof(header);
 
     unsigned char *buf_cipher = (unsigned char *) malloc(cipher_len);
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1189,7 +1189,7 @@ static void on_newPwButtonEnter_clicked(GtkEntry *button, gpointer data)
 
     int ret;
 
-    const string path = get_store_path(false);
+    const string path = get_store_path(DEFAULT_FILENAME, false);
 
     char msg[1024];
 

--- a/src/load.hpp
+++ b/src/load.hpp
@@ -36,12 +36,16 @@
 
 #define PASS_STORE_HEADER_SIZE (CRYPTO_HASH_SIZE + CRYPTO_SALT_SIZE + 1)
 
+#define DEFAULT_FILENAME ".spicypass"
+#define EXPORT_FILENAME  ".export_spicypass_plaintext"
+
 /*
- * Returns a string containing pass store file path.
+ * Returns a string containing the file path for `filename`
+ * in the home directory.
  *
  * Set `temp` to true for temp file path instead.
  */
-const string get_store_path(bool temp);
+const string get_store_path(const string filename, bool temp);
 
 /*
  * Attempts to validate password, decrypt password store, and load it into `p`.

--- a/src/load.hpp
+++ b/src/load.hpp
@@ -38,6 +38,7 @@
 
 #define DEFAULT_FILENAME ".spicypass"
 #define EXPORT_FILENAME  ".export_spicypass_plaintext"
+#define LOCK_FILENAME    ".~spicylock~"
 
 /*
  * Returns a string containing the file path for `filename`
@@ -45,7 +46,7 @@
  *
  * Set `temp` to true for temp file path instead.
  */
-const string get_store_path(const string filename, bool temp);
+const string get_store_path(const string &filename, bool temp);
 
 /*
  * Attempts to validate password, decrypt password store, and load it into `p`.
@@ -112,5 +113,20 @@ int export_pass_store_to_plaintext(Pass_Store &p);
  * Returns a string containing export file path.
  */
 string get_export_path(void);
+
+/*
+ * Deletes the file lock. Called on exit.
+ */
+bool delete_file_lock(void);
+
+/*
+ * Creates file lock. Called before any other file operations.
+ */
+bool create_file_lock(void);
+
+/*
+ * Return true if the spicypass file lock exists.
+ */
+bool file_lock_exists(void);
 
 #endif // LOAD_H

--- a/src/password.cpp
+++ b/src/password.cpp
@@ -74,7 +74,7 @@ static bool good_char(const char c, bool *have_lower, bool *have_upper,
         return true;
     }
 
-    Char_Type type = char_type(c);
+    const Char_Type type = char_type(c);
 
     switch (type) {
         case CHAR_UPPERCASE: {
@@ -129,8 +129,8 @@ static void shuffle_vec(vector<char> &vec)
     auto vec_size = vec.size();
 
     for (size_t i = 0; i < vec_size; ++i) {
-        auto index = crypto_random_number(vec_size);
-        auto a = vec.at(i);
+        const auto index = crypto_random_number(vec_size);
+        const auto a = vec.at(i);
         vec.at(i) = vec.at(index);
         vec.at(index) = a;
     }
@@ -140,7 +140,7 @@ string random_password(unsigned int size)
 {
     vector<char> result;
     vector<char> char_vec = string_to_vec(string(PRINTABLE_CHARS));
-    auto char_vec_size = char_vec.size();
+    const auto char_vec_size = char_vec.size();
 
     if (size < NUM_RAND_PASS_MIN_CHARS || size > NUM_RAND_PASS_MAX_CHARS) {
         cerr << "random_password() error: invalid size value" << endl;
@@ -154,8 +154,8 @@ string random_password(unsigned int size)
     char last_char = 0;
 
     do {
-        auto index = crypto_random_number(char_vec_size);
-        auto c = char_vec.at(index);
+        const auto index = crypto_random_number(char_vec_size);
+        const auto c = char_vec.at(index);
 
         if (c == last_char) {
             continue;

--- a/src/spicy.cpp
+++ b/src/spicy.cpp
@@ -67,7 +67,7 @@ void Pass_Store::signal_shutdown(void)
 bool Pass_Store::running(void)
 {
     s_lock();
-    bool is_running = !shutdown_signal;
+    const bool is_running = !shutdown_signal;
     s_unlock();
 
     return is_running;
@@ -83,7 +83,7 @@ void Pass_Store::set_gui_status(bool have_gui)
 bool Pass_Store::get_gui_status(void)
 {
     s_lock();
-    bool enabled = gui_enabled;
+    const bool enabled = gui_enabled;
     s_unlock();
 
     return enabled;
@@ -152,7 +152,7 @@ int Pass_Store::insert(const string &key, const string &value)
         return -1;
     }
 
-    size_t length = value.size();
+    const size_t length = value.size();
 
     if (length >= sizeof(pass->password)) {
         free(pass);
@@ -205,12 +205,12 @@ int Pass_Store::replace(const string &old_key, const string &new_key, const stri
         return PASS_STORE_LOCKED;
     }
 
-    bool keys_are_same = old_key == new_key;
+    const bool keys_are_same = old_key == new_key;
 
     s_lock();
 
     if (!keys_are_same) {
-        bool new_exists = store.find(new_key) != store.end();
+        const bool new_exists = store.find(new_key) != store.end();
 
         if (new_exists) {
             s_unlock();
@@ -238,7 +238,7 @@ int Pass_Store::key_exists(const string &key)
     }
 
     s_lock();
-    bool exists = store.find(key) != store.end();
+    const bool exists = store.find(key) != store.end();
     s_unlock();
 
     return exists ? 1 : 0;
@@ -334,7 +334,7 @@ int Pass_Store::load(ifstream &fp, size_t length, unsigned char format_version)
     }
 
     s_lock();
-    int ret = crypto_decrypt_file(fp, length, plaintext, &plain_length, encryption_key);
+    const int ret = crypto_decrypt_file(fp, length, plaintext, &plain_length, encryption_key);
     s_unlock();
 
     if (ret != 0) {
@@ -363,7 +363,7 @@ int Pass_Store::load(ifstream &fp, size_t length, unsigned char format_version)
     }
 
     plaintext[plain_length] = 0;
-    size_t num_entries = load_buffer((char *) plaintext, format_version);
+    const size_t num_entries = load_buffer((char *) plaintext, format_version);
 
     crypto_memwipe(plaintext, plain_length);
     free(plaintext);
@@ -377,7 +377,7 @@ int Pass_Store::save(ofstream &fp)
         return PASS_STORE_LOCKED;
     }
 
-    size_t file_size = size();
+    const size_t file_size = size();
 
     if (file_size == 0) {
         return 0;
@@ -397,7 +397,7 @@ int Pass_Store::save(ofstream &fp)
     unsigned long long out_len = 0;
 
     s_lock();
-    int ret = crypto_encrypt_file(fp, buf_in, file_size, &out_len, encryption_key);
+    const int ret = crypto_encrypt_file(fp, buf_in, file_size, &out_len, encryption_key);
     s_unlock();
 
     crypto_memwipe(buf_in, file_size);
@@ -491,7 +491,7 @@ size_t Pass_Store::load_buffer(char *buf, unsigned char format_version)
 
     while (t) {
         string entry = t;
-        auto d = entry.find(delimiter);
+        const auto d = entry.find(delimiter);
 
         if (d != string::npos) {
             string key = entry.substr(0, d);
@@ -515,7 +515,7 @@ bool Pass_Store::delete_entry(const string &key)
 {
     s_lock();
 
-    bool exists = store.find(key) != store.end();
+    const bool exists = store.find(key) != store.end();
 
     if (exists) {
         crypto_memunlock((unsigned char *) store.at(key)->password, sizeof(store.at(key)->password));


### PR DESCRIPTION
Now only one instance of SpicyPass can be run at once. This reduces the chances of file corruption or other strange bugs.