### PR TITLE
Make SpicyPass read-only when file lock exists

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -340,6 +340,11 @@ static int add(Pass_Store &p)
             return -1;
         }
 
+        case -4: {
+            cerr << "Failed to save password store: read-only mode is enabled" << endl;
+            return -1;
+        }
+
         default: {
             cerr << "Failed to save password store: Unknown error" << endl;
             return -1;

--- a/src/load.cpp
+++ b/src/load.cpp
@@ -182,6 +182,10 @@ static int read_header(ifstream &fp, unsigned char *format_version, unsigned cha
 
 int save_password_store(Pass_Store &p)
 {
+    if (p.get_read_only()) {
+        return -4;
+    }
+
     ofstream fp;
     get_pass_store_of(fp, p.get_save_file(), true);
 
@@ -410,6 +414,11 @@ int init_pass_hash(const unsigned char *password, size_t length, const string &s
 
 int update_crypto(Pass_Store &p, const unsigned char *password, size_t length)
 {
+    if (p.get_read_only()) {
+        cerr << "Cannot change the password in read-only mode." << endl;
+        return -4;
+    }
+
     unsigned char encryption_key[CRYPTO_KEY_SIZE];
     unsigned char salt[CRYPTO_SALT_SIZE];
     unsigned char hash[CRYPTO_HASH_SIZE] = {0};
@@ -495,8 +504,12 @@ int export_pass_store_to_plaintext(Pass_Store &p)
     return 0;
 }
 
-bool delete_file_lock(void)
+bool delete_file_lock(Pass_Store &p)
 {
+    if (p.get_read_only()) {
+        return true;
+    }
+
     const string lock_path = get_store_path(LOCK_FILENAME, false);
 
     if (lock_path.empty()) {
@@ -512,8 +525,12 @@ bool delete_file_lock(void)
     }
 }
 
-bool create_file_lock(void)
+bool create_file_lock(Pass_Store &p)
 {
+    if (p.get_read_only()) {
+        return true;
+    }
+
     const string lock_path = get_store_path(LOCK_FILENAME, false);
 
     if (lock_path.empty()) {

--- a/src/load.hpp
+++ b/src/load.hpp
@@ -68,6 +68,7 @@ int load_password_store(Pass_Store &p, const unsigned char *password, size_t len
  * Return -1 if path is invalid.
  * Return -2 if file encryption fails.
  * Return -3 if file save operation fails.
+ * Return -4 if read only mode is enabled.
  */
 int save_password_store(Pass_Store &p);
 
@@ -97,6 +98,7 @@ int init_pass_hash(const unsigned char *password, size_t length, const string &s
  * Return -1 on crypto related error.
  * Return -2 if `p` fails to update.
  * Return -3 on save failure.
+ * Return -4 if read only mode is enabled.
  * Return PASS_STORE_LOCKED if pass store is locked.
  */
 int update_crypto(Pass_Store &p, const unsigned char *password, size_t length);
@@ -116,13 +118,17 @@ string get_export_path(void);
 
 /*
  * Deletes the file lock. Called on exit.
+ *
+ * Return false on error.
  */
-bool delete_file_lock(void);
+bool delete_file_lock(Pass_Store &p);
 
 /*
  * Creates file lock. Called before any other file operations.
+ *
+ * Return false on file creation error.
  */
-bool create_file_lock(void);
+bool create_file_lock(Pass_Store &p);
 
 /*
  * Return true if the spicypass file lock exists.

--- a/src/spicy.hpp
+++ b/src/spicy.hpp
@@ -248,9 +248,17 @@ public:
     string get_save_file(void);
 
     /*
+     * If read only mode is set to true we cannot write to file. This is set when
+     * the file lock exists.
+     */
+    void set_read_only(bool read_only);
+    bool get_read_only(void);
+
+    /*
      * Securely wipes all sensitive pass store data from memory.
      */
     void clear(void);
+
     ~Pass_Store(void);
 
 private:
@@ -267,6 +275,7 @@ private:
     bool gui_enabled = false;
     bool idle_lock = false;
     bool shutdown_signal = false;
+    bool read_only_mode = false;
     time_t last_active = get_time();
 
     /*


### PR DESCRIPTION
This fixes the issue where the GUI would silently fail to open when the lock file exists without informing the user of what's going on. Now we can use all SpicyPass functionality when the file lock exists but modifications will not be saved to file.