### PR TITLE
Refactor and fix custom profile and export path handling

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -148,7 +148,7 @@ static int init_new_password(Pass_Store &p, unsigned char *password, size_t max_
 
     cout << "Generating new encryption key. This can take a while" << endl;
 
-    if (init_pass_hash(password, strlen((char *) password), p.get_save_file()) != 0) {
+    if (init_pass_hash(p, password, strlen((char *) password)) != 0) {
         cerr << "init_pass_hash() failed." << endl;
         return -1;
     }
@@ -583,7 +583,8 @@ static int export_entries(Pass_Store &p)
         return PASS_STORE_LOCKED;
     }
 
-    string export_path = get_store_path(EXPORT_FILENAME, false);
+    const string export_filename = p.get_save_file() + EXPORT_FILE_EXTENTION;
+    const string export_path = get_store_path(export_filename, false, p.using_custom_profile());
 
     if (export_path.size() == 0) {
         cerr << "Failed to export pass store." << endl;
@@ -614,7 +615,7 @@ static int export_entries(Pass_Store &p)
 
     cout << "Exported pass store entries to plaintext file: " << export_path << endl;
 
-    if (export_pass_store_to_plaintext(p) != 0) {
+    if (export_pass_store_to_plaintext(p, export_path) != 0) {
         cerr << "Failed to export pass store." << endl;
         return -1;
     }
@@ -708,7 +709,7 @@ int cli_new_pass_store(Pass_Store &p)
 {
     unsigned char password[MAX_STORE_PASSWORD_SIZE + 2];
 
-    if (first_time_run(p.get_save_file())) {
+    if (first_time_run(p)) {
         cout << "Creating a new profile. " << endl;
 
         if (init_new_password(p, password, sizeof(password) - 1) != 0) {

--- a/src/load.hpp
+++ b/src/load.hpp
@@ -37,16 +37,17 @@
 #define PASS_STORE_HEADER_SIZE (CRYPTO_HASH_SIZE + CRYPTO_SALT_SIZE + 1)
 
 #define DEFAULT_FILENAME ".spicypass"
-#define EXPORT_FILENAME  ".export_spicypass_plaintext"
 #define LOCK_FILENAME    ".~spicylock~"
+#define EXPORT_FILE_EXTENTION ".spicy_export"
 
 /*
  * Returns a string containing the file path for `filename`
  * in the home directory.
  *
- * Set `temp` to true for temp file path instead.
+ * If `custom_path` is true we don't use the home directory as the path base.
+ * If `temp` is true we append a tmp file extention to the file name.
  */
-const string get_store_path(const string &filename, bool temp);
+const string get_store_path(const string &filename, bool temp, bool custom_path);
 
 /*
  * Attempts to validate password, decrypt password store, and load it into `p`.
@@ -78,17 +79,17 @@ int save_password_store(Pass_Store &p);
  * Return -1 if invalid path.
  * Return -2 if file cannot be opened.
  */
-int first_time_run(const string &save_file);
+int first_time_run(Pass_Store &p);
 
 /*
  * Adds a header to the beginning of pass store file.
  *
- * This funciton should only be called when the pass store file is empty.
+ * This function should only be called when the pass store file is empty.
  *
  * Return 0 on success.
  * Return -1 on failure.
  */
-int init_pass_hash(const unsigned char *password, size_t length, const string &save_file);
+int init_pass_hash(Pass_Store &p, const unsigned char *password, size_t length);
 
 /*
  * Initializes `p` with a new encryption key derived from `password`, as well as a
@@ -104,12 +105,12 @@ int init_pass_hash(const unsigned char *password, size_t length, const string &s
 int update_crypto(Pass_Store &p, const unsigned char *password, size_t length);
 
 /*
- * Writes contents of pass store to a plaintext file.
+ * Writes contents of pass store to a plaintext file at `export_path`.
  *
  * Return 0 on success.
  * Return -1 on failure.
  */
-int export_pass_store_to_plaintext(Pass_Store &p);
+int export_pass_store_to_plaintext(Pass_Store &p, const string &export_path);
 
 /*
  * Returns a string containing export file path.
@@ -134,5 +135,8 @@ bool create_file_lock(Pass_Store &p);
  * Return true if the spicypass file lock exists.
  */
 bool file_lock_exists(void);
+
+/* Returns the file lock path. */
+const string get_lock_path(void);
 
 #endif // LOAD_H

--- a/src/spicy.hpp
+++ b/src/spicy.hpp
@@ -251,14 +251,20 @@ public:
     int _export(ofstream &fp);
 
     /*
-     * Sets the save file path to `save_file`.
+     * Sets the save file path to `save_file`. `set_custom_path` should be true
+     * if we're using a user-specified path (i.e. non-default).
      */
-    void set_save_file(const string &save_file);
+    void set_save_file(const string &save_file, bool set_custom_path);
 
     /*
      * Returns the current save file path.
      */
     string get_save_file(void);
+
+    /*
+     * Return true if a custom save file has been set by the user.
+     */
+    bool using_custom_profile(void);
 
     /*
      * If read only mode is set to true we cannot write to file. This is set when
@@ -282,9 +288,11 @@ private:
     unsigned char password_hash[CRYPTO_HASH_SIZE];
 
     string save_file;
+    bool custom_profile_set = false;
 
-    /* This mutex is responsible for protecting all variables and data stored within the Pass_Store instance. */
+    // This mutex is responsible for protecting all variables and data stored within the Pass_Store instance.
     mutex store_m;
+
     bool gui_enabled = false;
     bool idle_lock = false;
     bool shutdown_signal = false;


### PR DESCRIPTION
The --profile option will now use the full path provided instead of always using the home directory as a prefix. Additionally, export files will also use the base path provided instead of always putting the file in the home directory.