### PR TITLE
Update license stubs

### DIFF
--- a/gui/gui.glade
+++ b/gui/gui.glade
@@ -256,14 +256,14 @@
     <property name="skip-taskbar-hint">True</property>
     <property name="transient-for">window</property>
     <property name="program-name">SpicyPass</property>
-    <property name="copyright" translatable="yes">Copyright © 2020-2024 Jfreegman</property>
+    <property name="copyright" translatable="yes">Copyright © 2020-2025 Jfreegman</property>
     <property name="comments" translatable="yes">SpicyPass is a light-weight password manager that utilizes state of the art cryptography and minimalist design principles for secure and simple password storage. </property>
     <property name="website">https://github.com/Jfreegman/SpicyPass</property>
     <property name="website-label" translatable="yes">Source Code</property>
     <property name="authors">Jfreegman &lt;Jfreegman@gmail.com&gt;</property>
     <property name="artists">smashicons at flaticon.com</property>
     <property name="logo-icon-name">help-about</property>
-    <property name="license-type">gpl-3-0</property>
+    <property name="license-type">gpl-3-0-only</property>
     <child internal-child="vbox">
       <object class="GtkBox">
         <property name="can-focus">False</property>

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1,23 +1,9 @@
 /*  cli.cpp
  *
+ *  Copyright (C) 2020-2025 Jfreegman <Jfreegman@gmail.com>
  *
- *  Copyright (C) 2020-2024 Jfreegman <Jfreegman@gmail.com>
- *
- *  This file is part of SpicyPass.
- *
- *  SpicyPass is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  SpicyPass is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with SpicyPass.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  This file is part of SpicyPass. SpicyPass is free software licensed
+ *  under the GNU General Public License 3.0.
  */
 
 #include "load.hpp"

--- a/src/cli.hpp
+++ b/src/cli.hpp
@@ -1,23 +1,9 @@
 /*  cli.hpp
  *
+ *  Copyright (C) 2020-2025 Jfreegman <Jfreegman@gmail.com>
  *
- *  Copyright (C) 2020-2024 Jfreegman <Jfreegman@gmail.com>
- *
- *  This file is part of SpicyPass.
- *
- *  SpicyPass is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  SpicyPass is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with SpicyPass.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  This file is part of SpicyPass. SpicyPass is free software licensed
+ *  under the GNU General Public License 3.0.
  */
 
 #ifndef CLI_H

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -1,23 +1,9 @@
 /*  crypto.cpp
  *
+ *  Copyright (C) 2020-2025 Jfreegman <Jfreegman@gmail.com>
  *
- *  Copyright (C) 2020-2024 Jfreegman <Jfreegman@gmail.com>
- *
- *  This file is part of SpicyPass.
- *
- *  SpicyPass is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  SpicyPass is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with SpicyPass.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  This file is part of SpicyPass. SpicyPass is free software licensed
+ *  under the GNU General Public License 3.0.
  */
 
 #include <string.h>

--- a/src/crypto.hpp
+++ b/src/crypto.hpp
@@ -1,23 +1,9 @@
 /*  crypto.hpp
  *
+ *  Copyright (C) 2020-2025 Jfreegman <Jfreegman@gmail.com>
  *
- *  Copyright (C) 2020-2024 Jfreegman <Jfreegman@gmail.com>
- *
- *  This file is part of SpicyPass.
- *
- *  SpicyPass is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  SpicyPass is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with SpicyPass.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  This file is part of SpicyPass. SpicyPass is free software licensed
+ *  under the GNU General Public License 3.0.
  */
 
 #ifndef CRYPTO_H

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1,23 +1,9 @@
 /*  gui.cpp
  *
+ *  Copyright (C) 2020-2025 Jfreegman <Jfreegman@gmail.com>
  *
- *  Copyright (C) 2020-2024 Jfreegman <Jfreegman@gmail.com>
- *
- *  This file is part of SpicyPass.
- *
- *  SpicyPass is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  SpicyPass is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with SpicyPass.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  This file is part of SpicyPass. SpicyPass is free software licensed
+ *  under the GNU General Public License 3.0.
  */
 
 #ifdef GUI_SUPPORT

--- a/src/gui.hpp
+++ b/src/gui.hpp
@@ -1,23 +1,9 @@
 /*  gui.hpp
  *
+ *  Copyright (C) 2020-2025 Jfreegman <Jfreegman@gmail.com>
  *
- *  Copyright (C) 2020-2024 Jfreegman <Jfreegman@gmail.com>
- *
- *  This file is part of SpicyPass.
- *
- *  SpicyPass is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  SpicyPass is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with SpicyPass.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  This file is part of SpicyPass. SpicyPass is free software licensed
+ *  under the GNU General Public License 3.0.
  */
 
 #ifndef GUI_H

--- a/src/load.cpp
+++ b/src/load.cpp
@@ -1,23 +1,9 @@
 /*  load.cpp
  *
+ *  Copyright (C) 2020-2025 Jfreegman <Jfreegman@gmail.com>
  *
- *  Copyright (C) 2020-2024 Jfreegman <Jfreegman@gmail.com>
- *
- *  This file is part of SpicyPass.
- *
- *  SpicyPass is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  SpicyPass is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with SpicyPass.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  This file is part of SpicyPass. SpicyPass is free software licensed
+ *  under the GNU General Public License 3.0.
  */
 
 #include <cassert>

--- a/src/load.hpp
+++ b/src/load.hpp
@@ -1,23 +1,9 @@
 /*  load.hpp
  *
+ *  Copyright (C) 2020-2025 Jfreegman <Jfreegman@gmail.com>
  *
- *  Copyright (C) 2020-2024 Jfreegman <Jfreegman@gmail.com>
- *
- *  This file is part of SpicyPass.
- *
- *  SpicyPass is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  SpicyPass is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with SpicyPass.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  This file is part of SpicyPass. SpicyPass is free software licensed
+ *  under the GNU General Public License 3.0.
  */
 
 #ifndef LOAD_H

--- a/src/password.cpp
+++ b/src/password.cpp
@@ -1,23 +1,9 @@
 /*  password.cpp
  *
+ *  Copyright (C) 2020-2025 Jfreegman <Jfreegman@gmail.com>
  *
- *  Copyright (C) 2020-2024 Jfreegman <Jfreegman@gmail.com>
- *
- *  This file is part of SpicyPass.
- *
- *  SpicyPass is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  SpicyPass is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with SpicyPass.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  This file is part of SpicyPass. SpicyPass is free software licensed
+ *  under the GNU General Public License 3.0.
  */
 
 #include <string>

--- a/src/password.hpp
+++ b/src/password.hpp
@@ -1,23 +1,9 @@
 /*  password.hpp
  *
+ *  Copyright (C) 2020-2025 Jfreegman <Jfreegman@gmail.com>
  *
- *  Copyright (C) 2020-2024 Jfreegman <Jfreegman@gmail.com>
- *
- *  This file is part of SpicyPass.
- *
- *  SpicyPass is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  SpicyPass is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with SpicyPass.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  This file is part of SpicyPass. SpicyPass is free software licensed
+ *  under the GNU General Public License 3.0.
  */
 
 #ifndef PASSWORD_H

--- a/src/spicy.cpp
+++ b/src/spicy.cpp
@@ -1,23 +1,9 @@
 /*  spicy.cpp
  *
- *
  *  Copyright (C) 2020-2025 Jfreegman <Jfreegman@gmail.com>
  *
- *  This file is part of SpicyPass.
- *
- *  SpicyPass is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  SpicyPass is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with SpicyPass.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  This file is part of SpicyPass. SpicyPass is free software licensed
+ *  under the GNU General Public License 3.0.
  */
 
 #include <thread>

--- a/src/spicy.hpp
+++ b/src/spicy.hpp
@@ -1,23 +1,9 @@
 /*  spicy.hpp
  *
+ *  Copyright (C) 2020-2025 Jfreegman <Jfreegman@gmail.com>
  *
- *  Copyright (C) 2020-2024 Jfreegman <Jfreegman@gmail.com>
- *
- *  This file is part of SpicyPass.
- *
- *  SpicyPass is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  SpicyPass is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with SpicyPass.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  This file is part of SpicyPass. SpicyPass is free software licensed
+ *  under the GNU General Public License 3.0.
  */
 
 #ifndef SPICY_H

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,23 +1,9 @@
 /*  util.cpp
  *
+ *  Copyright (C) 2020-2025 Jfreegman <Jfreegman@gmail.com>
  *
- *  Copyright (C) 2020-2024 Jfreegman <Jfreegman@gmail.com>
- *
- *  This file is part of SpicyPass.
- *
- *  SpicyPass is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  SpicyPass is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with SpicyPass.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  This file is part of SpicyPass. SpicyPass is free software licensed
+ *  under the GNU General Public License 3.0.
  */
 
 #if defined(_WIN32)

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -1,23 +1,9 @@
 /*  util.hpp
  *
+ *  Copyright (C) 2020-2025 Jfreegman <Jfreegman@gmail.com>
  *
- *  Copyright (C) 2020-2024 Jfreegman <Jfreegman@gmail.com>
- *
- *  This file is part of SpicyPass.
- *
- *  SpicyPass is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
- *
- *  SpicyPass is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License
- *  along with SpicyPass.  If not, see <http://www.gnu.org/licenses/>.
- *
+ *  This file is part of SpicyPass. SpicyPass is free software licensed
+ *  under the GNU General Public License 3.0.
  */
 
 #ifndef UTIL_H


### PR DESCRIPTION
SpicyPass is now licensed under GPL v3.0-only