### PR TITLE
Notes no longer have a length limit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ set(DESKTOP_FILE_PATH ${APPLICATIONS_DIRECTORY}/spicypass.desktop)
 set(SpicyPass_LOGO_FILE_PATH ${SPICYPASS_INSTALL_DIRECTORY}/spicypass.svg)
 
 set(SpicyPass_VERSION_MAJOR "0")
-set(SpicyPass_VERSION_MINOR "10")
-set(SpicyPass_VERSION_PATCH "4")
+set(SpicyPass_VERSION_MINOR "11")
+set(SpicyPass_VERSION_PATCH "0")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -273,11 +273,6 @@ static int add(Pass_Store &p)
     cout << "Enter note (optional): ";
     getline(cin, note);
 
-    if (note.length() > MAX_STORE_NOTE_SIZE) {
-        cout << "Note must not exceed " << to_string(MAX_STORE_NOTE_SIZE) << " characters" << endl;
-        return -1;
-    }
-
     const int exists = p.key_exists(key);
 
     if (exists == PASS_STORE_LOCKED) {

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -306,11 +306,6 @@ static void on_addEntryButtonOk(GtkButton *button, gpointer data)
         goto on_exit;
     }
 
-    if (strlen(noteText) > MAX_STORE_NOTE_SIZE) {
-        snprintf(msg, sizeof(msg), "Note is too long");
-        goto on_exit;
-    }
-
     if (keylen == 0) {
         snprintf(msg, sizeof(msg), "Entry cannot be empty");
         goto on_exit;
@@ -461,11 +456,6 @@ static void on_editEntryButtonOk(GtkButton *button, gpointer data)
 
     if (strlen(passText) > MAX_STORE_PASSWORD_SIZE) {  // byte size does not always match `get_text_length()` value
         snprintf(msg, sizeof(msg), "Password is too long");
-        goto on_exit;
-    }
-
-    if (strlen(noteText) > MAX_STORE_NOTE_SIZE) {
-        snprintf(msg, sizeof(msg), "Note is too long");
         goto on_exit;
     }
 

--- a/src/spicy.hpp
+++ b/src/spicy.hpp
@@ -33,9 +33,6 @@ using namespace std;
 /* The minimum number of characters for a master password */
 #define MIN_MASTER_PASSWORD_SIZE  (8)
 
-/* The maximum number of characters for a pass store entry note */
-#define MAX_STORE_NOTE_SIZE   (5000)
-
 /* Return code indicating that `idle_lock` is set to true */
 #define PASS_STORE_LOCKED (INT_MIN)
 
@@ -63,7 +60,8 @@ enum {
  */
 struct Password {
     char password[MAX_STORE_PASSWORD_SIZE + 1];
-    char note[MAX_STORE_NOTE_SIZE + 1];
+    char *note;
+    size_t note_size; // includes null byte
 };
 
 


### PR DESCRIPTION
We now dynamically allocate memory for notes instead of using stack memory so that we can drop the arbitrary length limit.