### PR TITLE
Improve password shuffle algorithm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(SpicyPass_LOGO_FILE_PATH ${SPICYPASS_INSTALL_DIRECTORY}/spicypass.svg)
 
 set(SpicyPass_VERSION_MAJOR "0")
 set(SpicyPass_VERSION_MINOR "11")
-set(SpicyPass_VERSION_PATCH "2")
+set(SpicyPass_VERSION_PATCH "3")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/src/password.cpp
+++ b/src/password.cpp
@@ -112,13 +112,15 @@ static bool good_char(const char c, bool *have_lower, bool *have_upper,
  */
 static void shuffle_vec(vector<char> &vec)
 {
-    auto vec_size = vec.size();
+    const size_t vec_size = vec.size();
 
-    for (size_t i = 0; i < vec_size; ++i) {
-        const auto index = crypto_random_number(vec_size);
-        const auto a = vec.at(i);
-        vec.at(i) = vec.at(index);
-        vec.at(index) = a;
+    if (vec_size == 0) {
+        return;
+    }
+
+    for (size_t i = vec_size - 1; i > 0; --i) {
+        const auto index = crypto_random_number(i + 1);
+        swap(vec[i], vec[index]);
     }
 }
 


### PR DESCRIPTION
We now use the Knuth shuffle algorithm instead of a naive implementation to guarantee a uniform distribution. This does not increase security by any significant degree, but is theoretically the correct way to do things.