### PR TITLE
Refactor random password generator to return vector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(SpicyPass_LOGO_FILE_PATH ${SPICYPASS_INSTALL_DIRECTORY}/spicypass.svg)
 
 set(SpicyPass_VERSION_MAJOR "0")
 set(SpicyPass_VERSION_MINOR "11")
-set(SpicyPass_VERSION_PATCH "3")
+set(SpicyPass_VERSION_PATCH "4")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -273,7 +273,15 @@ static int add(Pass_Store &p)
     }
 
     if (password.empty()) {
-        password = random_password(16U);
+        vector<char> rand_pass = random_password(16U);
+
+        if (password_invalid(rand_pass)) {
+            cout << "Failed to generate random password" << endl;
+            return -1;
+        }
+
+        password = string(rand_pass.begin(), rand_pass.end());
+        crypto_memwipe((unsigned char *) rand_pass.data(), rand_pass.size());
 
         if (password.empty()) {
             cout << "Failed to generate random password" << endl;
@@ -482,14 +490,18 @@ static int generate(Pass_Store &p)
                  NUM_RAND_PASS_MAX_CHARS) << " characters in length" << endl;
     }
 
-    string pass = random_password(size);
+    vector<char> pass = random_password(size);
 
-    if (pass.empty()) {
+    if (password_invalid(pass)) {
         cout << "Failed to generate password" << endl;
         return -1;
     }
 
-    cout << pass << endl;
+    const char *pass_str = pass.data();
+
+    cout << pass_str << endl;
+
+    crypto_memwipe((unsigned char *) pass.data(), pass.size());
 
     return 0;
 }

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -423,10 +423,12 @@ static void on_buttonAdd_clicked(GtkButton *button, gpointer data)
 
     g_signal_connect(window, "key-press-event", G_CALLBACK(on_key_press), cb_data);
 
-    string password = random_password(16U);
+    vector<char> password = random_password(16U);
 
-    if (!password.empty()) {
-        gtk_entry_set_text(passEntry, password.c_str());
+    if (!password_invalid(password)) {
+        const char *pass_str = password.data();
+        gtk_entry_set_text(passEntry, pass_str);
+        crypto_memwipe((unsigned char *) password.data(), password.size());
     }
 
     if (p->check_lock()) {
@@ -1124,7 +1126,9 @@ static void on_menuPassGenGenerate_clicked(GtkButton *button, gpointer data)
     char msg[128];
     snprintf(msg, sizeof(msg), "Length must be a value between %d and %d", NUM_RAND_PASS_MIN_CHARS,
              NUM_RAND_PASS_MAX_CHARS);
-    string password;
+
+    vector<char> password;
+    const char *pass_str = NULL;
 
     if (text_length > RAND_PASS_ENTRY_MAX_LENGTH || text_length < 1) {
         goto on_exit;
@@ -1142,11 +1146,15 @@ static void on_menuPassGenGenerate_clicked(GtkButton *button, gpointer data)
 
     password = random_password(length);
 
-    if (password.empty()) {
+    if (password_invalid(password)) {
         goto on_exit;
     }
 
-    gtk_entry_set_text(entry2, password.c_str());
+    pass_str = password.data();
+
+    gtk_entry_set_text(entry2, pass_str);
+
+    crypto_memwipe((unsigned char *) password.data(), password.size());
 
     has_err = false;
 

--- a/src/password.cpp
+++ b/src/password.cpp
@@ -124,7 +124,16 @@ static void shuffle_vec(vector<char> &vec)
     }
 }
 
-string random_password(unsigned int size)
+bool password_invalid(const vector<char> &pass)
+{
+    if (pass.size() == 0) {
+        return true;
+    }
+
+    return pass[0] == '\0';
+}
+
+vector<char> random_password(unsigned int size)
 {
     vector<char> result;
     vector<char> char_vec = string_to_vec(string(PRINTABLE_CHARS));
@@ -132,7 +141,8 @@ string random_password(unsigned int size)
 
     if (size < NUM_RAND_PASS_MIN_CHARS || size > NUM_RAND_PASS_MAX_CHARS) {
         cerr << "random_password() error: invalid size value" << endl;
-        return "";
+        result.push_back('\0');
+        return result;
     }
 
     bool have_lower = false;
@@ -157,5 +167,7 @@ string random_password(unsigned int size)
 
     shuffle_vec(result);
 
-    return vec_to_string(result);
+    result.push_back('\0');
+
+    return result;
 }

--- a/src/password.hpp
+++ b/src/password.hpp
@@ -16,16 +16,26 @@
 #define NUM_RAND_PASS_MIN_CHARS (10)
 
 /*
- * Returns a cryptographically secure randomly generated password.
+ * Returns a cryptographically secure randomly generated password on success.
  *
  * `size` must be greater than or equal to the number of guaranteed characters (4)
- * and less than or equal to the total number of ASCII printable characters.
+ * and less than or equal to the total number of ASCII printable characters. If `size`
+ * is invalid, a vector containing a single null byte is returned.
  *
  * Password is guaranteed to meet minimum requirements as follows:
  * - At least one lower-case and upper-case letter
  * - At least one digit
  * - At least one symbol
+ *
+ * Use `password_invalid()` to ensure that the returned password is valid.
  */
-std::string random_password(unsigned int size);
+std::vector<char> random_password(unsigned int size);
+
+/*
+ * Returns true if `pass` is either empty, or contains a null byte at index 0.
+ *
+ * This function should be called to ensure that `random_password` succeeded.
+ */
+bool password_invalid(const std::vector<char> &pass);
 
 #endif // PASSWORD_H


### PR DESCRIPTION
Returning a vector instead of a string allows us to more effectively wipe passwords from memory after use